### PR TITLE
Fix crash on Mac

### DIFF
--- a/Source/SteelSeriesGameSense/Private/SSGS_ClientPrivate.cpp
+++ b/Source/SteelSeriesGameSense/Private/SSGS_ClientPrivate.cpp
@@ -227,8 +227,7 @@ public:
     }
 
     template < typename msg_type >
-    _queue_msg_wrapper_( const msg_type& v ) :
-        _activeTag( msg_type::tag )
+    _queue_msg_wrapper_( const msg_type& v )
     {
         set( v );
     }


### PR DESCRIPTION
Seems like the default constructor is initializing _v.invalid, but then the active tag gets assigned to something different before calling set. So by the time _destroyByTag gets called, it releases the incorrect member