### PR TITLE
Add GameSense server ping with exponential backoff

### DIFF
--- a/Source/SteelSeriesGameSense/Private/SSGS_ClientPrivate.cpp
+++ b/Source/SteelSeriesGameSense/Private/SSGS_ClientPrivate.cpp
@@ -496,7 +496,7 @@ bool _doProbing( const FString& serverPort )
             retryRequest = false;
         }
 
-        // Wait (2 ^ retires * 200) milliseconds
+        // Wait (2 ^ retries * 200) milliseconds
         FPlatformProcess::Sleep( (1 << retries) * 0.2f );
         FHttpResponsePtr responsePtr = requestPtr->GetResponse();
         bool responsePtrValid = responsePtr.IsValid();


### PR DESCRIPTION
The client now pings the GameSense server during the "probing" state to
determine if it should continue communication.

This also switches to using the FEvent interface instead of Promises and
Future objects for barriers since our use of promises left a lot of room
for potential crashes due to "broken" promises.

This should address issue #9