### PR TITLE
Fix C4577 using Unreal Engine 4.21 with Visual Studio 2017.

### DIFF
--- a/Source/SteelSeriesGameSense/SteelSeriesGameSense.Build.cs
+++ b/Source/SteelSeriesGameSense/SteelSeriesGameSense.Build.cs
@@ -14,7 +14,8 @@ namespace UnrealBuildTool.Rules
         {
             bEnforceIWYU = false;
             PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-
+            bEnableExceptions = true;
+			
             PublicDependencyModuleNames.AddRange(
                 new string[]
                 {


### PR DESCRIPTION
Fixes compiler error C4577 using Unreal Engine 4.21 with Visual Studio 2017. The error occurs only when packaging a build, not when compiling the editor:

See https://answers.unrealengine.com/questions/348151/c4577-noexcept-used-with-no-exception-handling-mod.html for details.